### PR TITLE
Parallel Select

### DIFF
--- a/csharp/src/ArmoniK.Utils.csproj
+++ b/csharp/src/ArmoniK.Utils.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2022.*"/>
+    <PackageReference Include="JetBrains.Annotations" Version="2022.*" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/csharp/src/ExecutionSingleizer.cs
+++ b/csharp/src/ExecutionSingleizer.cs
@@ -140,15 +140,9 @@ public class ExecutionSingleizer<T> : IDisposable
     // Wait for task.
     try
     {
-      // Allow for early exit.
-      var tcs = new TaskCompletionSource<T>();
-
-      // Early exit if the current cancellationToken is cancelled.
-      cancellationToken.Register(() => tcs.SetCanceled());
-
       // Wait for either the task to finish, or the cancellation token to be cancelled.
       return await Task.WhenAny(task,
-                                tcs.Task)
+                                cancellationToken.AsTask<T>())
                        .Unwrap()
                        .ConfigureAwait(false);
     }

--- a/csharp/src/ParallelSelectExt.cs
+++ b/csharp/src/ParallelSelectExt.cs
@@ -1,0 +1,288 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-2023.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using JetBrains.Annotations;
+
+namespace ArmoniK.Utils;
+
+[PublicAPI]
+public static class ParallelSelectExt
+{
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks.
+  ///   At most `parallelism` tasks will be running at any given time.
+  ///   If `parallelism` is 0 or negative, number of threads is used.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="parallelism">Maximum number of parallel tasks to be spawned at any moment</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="T">Return type of the tasks</typeparam>
+  /// <returns>Asynchronous results of tasks</returns>
+  [PublicAPI]
+  public static async IAsyncEnumerable<T> ParallelWait<T>(this IEnumerable<Task<T>>                  enumerable,
+                                                          int                                        parallelism,
+                                                          [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    // If parallelism is 0 or negative, use number of threads
+    if (parallelism < 1)
+    {
+      parallelism = Environment.ProcessorCount;
+    }
+
+    // cancellation task for early exit
+    var cancelled = cancellationToken.AsTask<T>();
+    // Circular buffer of tasks for the queue
+    var buffer = new Task<T>[parallelism];
+    // number of tasks processed
+    var n = 0;
+
+    foreach (var x in enumerable)
+    {
+      var i = n % parallelism;
+
+      // We should dequeue tasks only if we enqueued enough
+      if (n >= parallelism)
+      {
+        // Dequeue a new task and wait for its result
+        // Early exit if cancellation is requested
+        yield return await Task.WhenAny(buffer[i],
+                                        cancelled)
+                               .Unwrap()
+                               .ConfigureAwait(false);
+      }
+
+      // Enqueue a new task
+      buffer[i] =  x;
+      n         += 1;
+
+      // not strictly required, but can help stop earlier if the enumerable is slow to move
+      cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    // Dequeue remaining tasks
+    for (var i = Math.Max(0,
+                          n - parallelism); i < n; i += 1)
+    {
+      // Dequeue a new task and wait for its result
+      // Early exit if cancellation is requested
+      yield return await Task.WhenAny(buffer[i],
+                                      cancelled)
+                             .Unwrap()
+                             .ConfigureAwait(false);
+    }
+  }
+
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks.
+  ///   At most `parallelism` tasks will be running at any given time.
+  ///   If `parallelism` is 0 or negative, number of threads is used.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="parallelism">Maximum number of parallel tasks to be spawned at any moment</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="T">Return type of the tasks</typeparam>
+  /// <returns>Asynchronous results of tasks</returns>
+  [PublicAPI]
+  public static async IAsyncEnumerable<T> ParallelWait<T>(this IAsyncEnumerable<Task<T>>             enumerable,
+                                                          int                                        parallelism,
+                                                          [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    // If parallelism is 0 or negative, use number of threads
+    if (parallelism < 1)
+    {
+      parallelism = Environment.ProcessorCount;
+    }
+
+    // cancellation tasks for early exit
+    var cancelledV = cancellationToken.AsTask<T>();
+    var cancelledB = cancellationToken.AsTask<bool>();
+    // Circular buffer of tasks for the queue
+    var buffer = new Task<T>[parallelism];
+    // number of tasks processed
+    var n = 0;
+
+    // Manual enumeration allow for overlapping gets and yields
+    await using var enumerator = enumerable.GetAsyncEnumerator(cancellationToken);
+    // Start first move
+    var moveTask = enumerator.MoveNextAsync()
+                             .AsTask();
+
+    // Iterate over the enumerator, with early exit on cancellation
+    while (await Task.WhenAny(moveTask,
+                              cancelledB)
+                     .Unwrap()
+                     .ConfigureAwait(false))
+    {
+      var x = enumerator.Current;
+      var i = n % parallelism;
+
+      // Start next move
+      moveTask = enumerator.MoveNextAsync()
+                           .AsTask();
+
+      // We should dequeue tasks only if we enqueued enough
+      if (n >= parallelism)
+      {
+        // Dequeue a new task and wait for its result
+        // Early exit if cancellation is requested
+        yield return await Task.WhenAny(buffer[i],
+                                        cancelledV)
+                               .Unwrap()
+                               .ConfigureAwait(false);
+      }
+
+      // Enqueue a new task
+      buffer[i] =  x;
+      n         += 1;
+    }
+
+    // Dequeue remaining tasks
+    for (var i = Math.Max(0,
+                          n - parallelism); i < n; i += 1)
+    {
+      // Dequeue a new task and wait for its result
+      // Early exit if cancellation is requested
+      yield return await Task.WhenAny(buffer[i],
+                                      cancelledV)
+                             .Unwrap()
+                             .ConfigureAwait(false);
+    }
+  }
+
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks.
+  ///   At most "number of thread" tasks will be running at any given time.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="T">Return type of the tasks</typeparam>
+  /// <returns>Asynchronous results of tasks</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<T> ParallelWait<T>(this IEnumerable<Task<T>> enumerable,
+                                                    CancellationToken         cancellationToken = default)
+    => ParallelWait(enumerable,
+                    0,
+                    cancellationToken);
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks.
+  ///   At most "number of thread" tasks will be running at any given time.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="T">Return type of the tasks</typeparam>
+  /// <returns>Asynchronous results of tasks</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<T> ParallelWait<T>(this IAsyncEnumerable<Task<T>> enumerable,
+                                                    CancellationToken              cancellationToken = default)
+    => ParallelWait(enumerable,
+                    0,
+                    cancellationToken);
+
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks that call `func`.
+  ///   At most `parallelism` tasks will be running at any given time.
+  ///   If `parallelism` is 0 or negative, number of threads is used.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="parallelism">Maximum number of parallel tasks to be spawned at any moment</param>
+  /// <param name="func">Function to spawn on the enumerable input</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="TU">Type of the inputs</typeparam>
+  /// <typeparam name="TV">Type of the outputs</typeparam>
+  /// <returns>Asynchronous results of func over the inputs</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<TV> ParallelSelect<TU, TV>(this IEnumerable<TU> enumerable,
+                                                            int                  parallelism,
+                                                            Func<TU, Task<TV>>   func,
+                                                            CancellationToken    cancellationToken = default)
+    => ParallelWait(enumerable.Select(func),
+                    parallelism,
+                    cancellationToken);
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks that call `func`.
+  ///   At most `parallelism` tasks will be running at any given time.
+  ///   If `parallelism` is 0 or negative, number of threads is used.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="parallelism">Maximum number of parallel tasks to be spawned at any moment</param>
+  /// <param name="func">Function to spawn on the enumerable input</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="TU">Type of the inputs</typeparam>
+  /// <typeparam name="TV">Type of the outputs</typeparam>
+  /// <returns>Asynchronous results of func over the inputs</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<TV> ParallelSelect<TU, TV>(this IAsyncEnumerable<TU> enumerable,
+                                                            int                       parallelism,
+                                                            Func<TU, Task<TV>>        func,
+                                                            CancellationToken         cancellationToken = default)
+    => ParallelWait(enumerable.Select(func),
+                    parallelism,
+                    cancellationToken);
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks that call `func`.
+  ///   At most "number of thread" tasks will be running at any given time.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="func">Function to spawn on the enumerable input</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="TU">Type of the inputs</typeparam>
+  /// <typeparam name="TV">Type of the outputs</typeparam>
+  /// <returns>Asynchronous results of func over the inputs</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<TV> ParallelSelect<TU, TV>(this IEnumerable<TU> enumerable,
+                                                            Func<TU, Task<TV>>   func,
+                                                            CancellationToken    cancellationToken = default)
+    => ParallelWait(enumerable.Select(func),
+                    cancellationToken);
+
+  /// <summary>
+  ///   Iterates over the input enumerable and spawn multiple parallel tasks that call `func`.
+  ///   At most "number of thread" tasks will be running at any given time.
+  ///   All results are collected in-order.
+  /// </summary>
+  /// <param name="enumerable">Enumerable to iterate on</param>
+  /// <param name="func">Function to spawn on the enumerable input</param>
+  /// <param name="cancellationToken">Token to cancel the enumeration</param>
+  /// <typeparam name="TU">Type of the inputs</typeparam>
+  /// <typeparam name="TV">Type of the outputs</typeparam>
+  /// <returns>Asynchronous results of func over the inputs</returns>
+  [PublicAPI]
+  public static IAsyncEnumerable<TV> ParallelSelect<TU, TV>(this IAsyncEnumerable<TU> enumerable,
+                                                            Func<TU, Task<TV>>        func,
+                                                            CancellationToken         cancellationToken = default)
+    => ParallelWait(enumerable.Select(func),
+                    cancellationToken);
+}

--- a/csharp/src/ParallelSelectExt.cs
+++ b/csharp/src/ParallelSelectExt.cs
@@ -86,7 +86,7 @@ public static class ParallelSelectExt
     {
       // Dequeue a new task and wait for its result
       // Early exit if cancellation is requested
-      yield return await Task.WhenAny(buffer[i],
+      yield return await Task.WhenAny(buffer[i % parallelism],
                                       cancelled)
                              .Unwrap()
                              .ConfigureAwait(false);
@@ -165,7 +165,7 @@ public static class ParallelSelectExt
     {
       // Dequeue a new task and wait for its result
       // Early exit if cancellation is requested
-      yield return await Task.WhenAny(buffer[i],
+      yield return await Task.WhenAny(buffer[i % parallelism],
                                       cancelledV)
                              .Unwrap()
                              .ConfigureAwait(false);

--- a/csharp/src/TaskExt.cs
+++ b/csharp/src/TaskExt.cs
@@ -16,6 +16,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using JetBrains.Annotations;
@@ -107,4 +108,30 @@ public static class TaskExt
   [PublicAPI]
   public static async Task<List<T>> ToListAsync<T>(this Task<IEnumerable<T>> enumerableTask)
     => (await enumerableTask.ConfigureAwait(false)).ToList();
+
+  /// <summary>
+  ///   Convert a Cancellation Token into a Task.
+  ///   The task will wait for the cancellation token to be cancelled and throw an exception.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation Token to convert</param>
+  /// <typeparam name="T">Type of the (unused) result of the task</typeparam>
+  /// <returns>Task that will be completed upon cancellation</returns>
+  [PublicAPI]
+  public static Task<T> AsTask<T>(this CancellationToken cancellationToken)
+  {
+    var tcs = new TaskCompletionSource<T>();
+    cancellationToken.Register(() => tcs.SetCanceled());
+    return tcs.Task;
+  }
+
+  /// <summary>
+  ///   Convert a Cancellation Token into a Task.
+  ///   The task will wait for the cancellation token to be cancelled and throw an exception.
+  /// </summary>
+  /// <param name="cancellationToken">Cancellation Token to convert</param>
+  /// <typeparam name="T">Type of the (unused) result of the task</typeparam>
+  /// <returns>Task that will be completed upon cancellation</returns>
+  [PublicAPI]
+  public static Task AsTask(this CancellationToken cancellationToken)
+    => cancellationToken.AsTask<int>();
 }

--- a/csharp/tests/ArmoniK.Utils.Tests.csproj
+++ b/csharp/tests/ArmoniK.Utils.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-    <PackageReference Include="NUnit" Version="3.13.3"/>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>
-    <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../src/ArmoniK.Utils.csproj"/>
+    <ProjectReference Include="../src/ArmoniK.Utils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/tests/ParallelSelectExtTest.cs
+++ b/csharp/tests/ParallelSelectExtTest.cs
@@ -1,0 +1,117 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-2023.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace ArmoniK.Utils.Tests;
+
+public class ParallelSelectExtTest
+{
+  [Test]
+  [TestCase(0, -1)]
+  [TestCase(1, -1)]
+  [TestCase(4, -1)]
+  [TestCase(0, 0)]
+  [TestCase(1, 0)]
+  [TestCase(4, 0)]
+  [TestCase(0, 1)]
+  [TestCase(1, 1)]
+  [TestCase(4, 1)]
+  [TestCase(0, 2)]
+  [TestCase(1, 2)]
+  [TestCase(4, 2)]
+  public async Task ParallelSelectShouldWork(int parallelism, int n)
+  {
+    var x = await GenerateInts(n)
+            .ParallelSelect(parallelism,
+                            AsyncIdentity(10))
+            .ToListAsync().ConfigureAwait(false);
+    var y = GenerateInts(n)
+      .ToList();
+    Assert.That(x, Is.EqualTo(y));
+  }
+
+  [Test]
+  [TestCase(0, -1)]
+  [TestCase(1, -1)]
+  [TestCase(4, -1)]
+  [TestCase(0, 0)]
+  [TestCase(1, 0)]
+  [TestCase(4, 0)]
+  [TestCase(0, 1)]
+  [TestCase(1, 1)]
+  [TestCase(4, 1)]
+  [TestCase(0, 2)]
+  [TestCase(1, 2)]
+  [TestCase(4, 2)]
+  public async Task ParallelSelectAsyncShouldWork(int n, int parallelism)
+  {
+    var x = await GenerateIntsAsync(n, 10)
+                  .ParallelSelect(parallelism,
+                                  AsyncIdentity(10))
+                  .ToListAsync().ConfigureAwait(false);
+    var y = GenerateInts(n)
+      .ToList();
+    Assert.That(x, Is.EqualTo(y));
+  }
+
+
+  private static IEnumerable<int> GenerateInts(int n)
+  {
+    for (var i = 0; i < n; ++i)
+    {
+      yield return i;
+    }
+  }
+
+  private static async IAsyncEnumerable<int> GenerateIntsAsync(int                n,
+                                                               int                delay,
+                                                               [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    for (var i = 0; i < n; ++i)
+    {
+      if (delay > 0)
+      {
+        await Task.Delay(delay,
+                         cancellationToken)
+                  .ConfigureAwait(false);
+      }
+
+      yield return i;
+    }
+  }
+
+  private static Func<int, Task<int>> AsyncIdentity(int               delay,
+                                                    CancellationToken cancellationToken = default)
+    => async x =>
+       {
+         if (delay > 0)
+         {
+           await Task.Delay(delay,
+                            cancellationToken)
+                     .ConfigureAwait(false);
+         }
+
+         return x;
+       };
+}


### PR DESCRIPTION
Implementation of the `ParallelSelect` utility.
`ParallelSelect` takes an `IEnumerable` or `IAsyncEnumerable`, and applies an asynchronous function in parallel to the elements, with the possibility to limit the parallelism.