### PR TITLE
fix: enumerator dispose

### DIFF
--- a/csharp/src/ParallelSelectExt.cs
+++ b/csharp/src/ParallelSelectExt.cs
@@ -157,7 +157,7 @@ public static class ParallelSelectExt
     var semAcquire = sem.WaitAsync(cts.Token);
 
     // Manual enumeration allow for overlapping gets and yields
-    await using var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
+    var enumerator = enumerable.GetAsyncEnumerator(cts.Token);
 
     Task<bool> MoveNext()
       => enumerator.MoveNextAsync()
@@ -253,6 +253,8 @@ public static class ParallelSelectExt
 
     // Dispose should be done only on the successful path.
     // Otherwise, semaphore might be used by some background tasks.
+    await enumerator.DisposeAsync()
+                    .ConfigureAwait(false);
     sem.Dispose();
     cts.Dispose();
   }


### PR DESCRIPTION
Upon cancellation, enumeration might continue in background even after the enumerator has been disposed. To ensure it does not happen, this PR make the call to dispose only on the successful path.