### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,30 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base",
-              "group:allNonMajor",
-              ":semanticCommits"
-             ],
-  "packageRules":
-  [
+  "extends": [
+    "config:base",
+    "group:allNonMajor",
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "rangeStrategy": "bump",
+  "packageRules": [
     {
-      "matchPackagePrefixes": ["ArmoniK"],
-      "groupName": "release packages Armonik"
+      "groupName": "nuget packages",
+      "groupSlug": "nuget",
+      "excludePackagePrefixes": [
+        "ArmoniK.Api",
+        "ArmoniK.Utils"
+      ],
+      "matchDatasources": [
+        "nuget"
+      ]
     },
     {
-
-    "matchPackagePatterns": ["*"],
-    "excludePackagePrefixes": ["ArmoniK"],
-    "groupName": "other dependencies"  
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,6 @@
     {
       "groupName": "nuget packages",
       "groupSlug": "nuget",
-      "excludePackagePrefixes": [
-        "ArmoniK.Api",
-        "ArmoniK.Utils"
-      ],
       "matchDatasources": [
         "nuget"
       ]


### PR DESCRIPTION
I update renovate config to match repo datasources.

We need to pin actions for security reasons.

You can find an example at https://github.com/esoubiran-aneo/ArmoniK.Utils