### PR TITLE
fix: Double validity check for ObjectPool

### DIFF
--- a/csharp/src/ObjectPool.cs
+++ b/csharp/src/ObjectPool.cs
@@ -238,7 +238,7 @@ public class ObjectPool<T> : IDisposable, IAsyncDisposable
 
     try
     {
-      if (bag_.TryTake(out var res))
+      while (bag_.TryTake(out var res))
       {
         var isValid = validateFunc_ is null || await validateFunc_(res,
                                                                    cancellationToken)


### PR DESCRIPTION
When using an `ObjectPool`, object validity is checked twice:
- Upon Acquire when the object is reused
- Upon Release

This should fix issues with objects whose validity can expire when the object is pending within the pool.