### PR TITLE
chore(deps): prepare update to Nunit 4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,8 +68,6 @@ jobs:
             framework: "net4.7"
           - version: ""
             framework: "net4.8"
-          - version: "5.0"
-            framework: "net5.0"
           - version: "6.0"
             framework: "net6.0"
           - version: "7.0"

--- a/csharp/tests/ArmoniK.Utils.Tests.csproj
+++ b/csharp/tests/ArmoniK.Utils.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
-    <TargetFrameworks>net4.7;net4.8;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net4.7;net4.8;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
 

--- a/csharp/tests/ExecutionSingleizerTest.cs
+++ b/csharp/tests/ExecutionSingleizerTest.cs
@@ -138,8 +138,8 @@ public class ExecutionSingleizerTest
     for (var i = 0; i < n; ++i)
     {
       var j = results[i];
-      Assert.GreaterOrEqual(i,
-                            j);
+      Assert.That(j,
+                  Is.LessThanOrEqualTo(i));
     }
   }
 


### PR DESCRIPTION
Update to Nunit4 is not possible for now as the CodeAnalysis NunitVerifier is not compatible with Nunit 4. This PR prepare for the update by fixing everything that will be needed for the update:
- Remove .net 5
- Remove old asserts