### PR TITLE
chore: add document extraction tool

### DIFF
--- a/csharp/ArmoniK.Utils.sln
+++ b/csharp/ArmoniK.Utils.sln
@@ -8,6 +8,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Utils.Diagnostics",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Utils.Diagnostics.Sample", "diagnostics.sample\ArmoniK.Utils.Diagnostics.Sample.csproj", "{720DB760-D7A2-4DD1-B0EB-2A36AB60F088}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Utils.DocExtractor", "documentation\src\ArmoniK.Utils.DocExtractor.csproj", "{58B3E53E-98A7-45DF-BEFF-3813D18DD788}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Utils.DocExtractor.Tests", "documentation\tests\ArmoniK.Utils.DocExtractor.Tests.csproj", "{28867143-0E8E-4292-8DC4-B6BD9B3BBD7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +34,13 @@ Global
 		{720DB760-D7A2-4DD1-B0EB-2A36AB60F088}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{720DB760-D7A2-4DD1-B0EB-2A36AB60F088}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{720DB760-D7A2-4DD1-B0EB-2A36AB60F088}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58B3E53E-98A7-45DF-BEFF-3813D18DD788}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58B3E53E-98A7-45DF-BEFF-3813D18DD788}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58B3E53E-98A7-45DF-BEFF-3813D18DD788}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58B3E53E-98A7-45DF-BEFF-3813D18DD788}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28867143-0E8E-4292-8DC4-B6BD9B3BBD7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28867143-0E8E-4292-8DC4-B6BD9B3BBD7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28867143-0E8E-4292-8DC4-B6BD9B3BBD7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28867143-0E8E-4292-8DC4-B6BD9B3BBD7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/csharp/documentation/src/ArmoniK.Utils.DocExtractor.csproj
+++ b/csharp/documentation/src/ArmoniK.Utils.DocExtractor.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>ArmoniK.Utils.DocExtractor</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="MarkdownDocExtractor.cs">
+        <Link>MarkdownDocExtractor.cs</Link>
+      </Compile>
+    </ItemGroup>
+
+</Project>

--- a/csharp/documentation/src/ExtractDocumentationAttribute.cs
+++ b/csharp/documentation/src/ExtractDocumentationAttribute.cs
@@ -1,0 +1,37 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-$CURRENT_YEAR.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ArmoniK.Utils.DocExtractor;
+
+/// <summary>
+///   Indicates that a class should have its property documentation collected.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class,
+                Inherited = false)]
+public class ExtractDocumentationAttribute : Attribute
+{
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ExtractDocumentationAttribute" /> class.
+  /// </summary>
+  /// <param name="description">An optional description for the attribute, providing context about the class.</param>
+  public ExtractDocumentationAttribute(string description = "")
+    => Description = description;
+
+  /// <summary>
+  ///   Gets the description of the attribute.
+  /// </summary>
+  public string Description { get; }
+}

--- a/csharp/documentation/src/MarkdownDocExtractor.cs
+++ b/csharp/documentation/src/MarkdownDocExtractor.cs
@@ -1,0 +1,130 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-2023.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace ArmoniK.Utils.DocExtractor;
+
+/// <summary>
+/// Utility class to generate Markdown documentation from C# source code
+/// by extracting classes annotated with the <c>ExtractDocumentation</c> attribute.
+/// </summary>
+public abstract class MarkdownDocGenerator
+{
+    /// <summary>
+    /// Parses the given solution file and generates a Markdown string
+    /// documenting all classes with the <c>[ExtractDocumentation]</c> attribute
+    /// and their properties.
+    /// </summary>
+    /// <param name="solutionPath">Path to the .sln file.</param>
+    /// <returns>
+    /// A Markdown-formatted string with environment variable documentation,
+    /// or <c>null</c> if the solution file does not exist.
+    /// </returns>
+    public static async Task<string?> GenerateAsync(string solutionPath)
+    {
+        if (!File.Exists(solutionPath))
+        {
+          return null;
+        }
+
+        using var workspace = MSBuildWorkspace.Create();
+        var solution = await workspace.OpenSolutionAsync(solutionPath).ConfigureAwait(false);
+
+        var markdownBuilder = new StringBuilder();
+
+        foreach (var project in solution.Projects)
+        {
+            foreach (var document in project.Documents)
+            {
+                var syntaxTree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
+                if (syntaxTree == null)
+                {
+                  continue;
+                }
+
+                var root = await syntaxTree.GetRootAsync().ConfigureAwait(false);
+                var markdown = GenerateFromSyntaxRoot(root);
+                markdownBuilder.Append(markdown);
+            }
+        }
+
+        return markdownBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Generates Markdown documentation from a Roslyn <see cref="SyntaxNode"/>.
+    /// Only classes decorated with <c>[ExtractDocumentation]</c> will be processed.
+    /// </summary>
+    /// <param name="root">The root syntax node of the document.</param>
+    /// <returns>A Markdown string documenting the class and its public properties.</returns>
+    public static string GenerateFromSyntaxRoot(SyntaxNode root)
+    {
+        var markdownBuilder = new StringBuilder();
+
+        var classes = root.DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .Where(c => c.AttributeLists
+                .SelectMany(a => a.Attributes)
+                .Any(attr => attr.Name.ToString() == "ExtractDocumentation"));
+
+        foreach (var classDeclaration in classes)
+        {
+            var extractDocumentationAttribute = classDeclaration.AttributeLists
+                .SelectMany(a => a.Attributes)
+                .FirstOrDefault(attr => attr.Name.ToString() == "ExtractDocumentation");
+
+            var description = extractDocumentationAttribute?.ArgumentList?.Arguments
+                .FirstOrDefault()?.ToString().Trim('"');
+
+            markdownBuilder.AppendLine($"## {description}");
+
+            var properties = classDeclaration.Members.OfType<PropertyDeclarationSyntax>();
+            foreach (var property in properties)
+            {
+                var type = property.Type.ToString();
+                var name = property.Identifier.Text;
+
+                var xmlComment = property.GetLeadingTrivia()
+                    .Select(trivia => trivia.GetStructure())
+                    .OfType<DocumentationCommentTriviaSyntax>()
+                    .FirstOrDefault();
+
+                var summary = xmlComment?.Content
+                    .OfType<XmlElementSyntax>()
+                    .FirstOrDefault(e => e.StartTag.Name.ToString() == "summary")?
+                    .Content.ToFullString().Trim();
+                summary = summary?.Replace("///", "");
+
+                var envVar = $"{classDeclaration.Identifier.Text}__{name}";
+
+                markdownBuilder.AppendLine($"- **{envVar}**: {type}");
+                if (!string.IsNullOrEmpty(summary))
+                {
+                    markdownBuilder.AppendLine($"\n{summary}");
+                }
+            }
+
+            markdownBuilder.AppendLine();
+        }
+
+        return markdownBuilder.ToString();
+    }
+}

--- a/csharp/documentation/src/Program.cs
+++ b/csharp/documentation/src/Program.cs
@@ -1,0 +1,50 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-2023.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ArmoniK.Utils.DocExtractor;
+
+internal abstract class Program
+{
+  private static async Task Main(string[] args)
+  {
+    if (args.Length == 0)
+    {
+      Console.WriteLine("Please provide the path to the solution file.");
+      return;
+    }
+
+    var solutionPath = args[0];
+
+    if (!File.Exists(solutionPath))
+    {
+      Console.WriteLine($"Given solution file {solutionPath} does not exist.");
+      return;
+    }
+
+    var markdown  = await MarkdownDocGenerator.GenerateAsync(solutionPath);
+
+    if (markdown is null)
+    {
+      Console.WriteLine($"Failed to load solution from path: {solutionPath}");
+      return;
+    }
+
+    var outputFileName = Path.GetFileNameWithoutExtension(solutionPath) + ".EnvVars.md";
+    await File.WriteAllTextAsync(outputFileName,
+                                 markdown);
+    Console.WriteLine($"Markdown file generated: {outputFileName}");
+  }
+}

--- a/csharp/documentation/tests/ArmoniK.Utils.DocExtractor.Tests.csproj
+++ b/csharp/documentation/tests/ArmoniK.Utils.DocExtractor.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <RootNamespace>ArmoniK.Utils.DocExtractor.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="NUnit" Version="3.13.3"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
+        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\ArmoniK.Utils.DocExtractor.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/csharp/documentation/tests/ExtractDocumentationTest.cs
+++ b/csharp/documentation/tests/ExtractDocumentationTest.cs
@@ -1,0 +1,55 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2022-2023.All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.CodeAnalysis.CSharp;
+
+using NUnit.Framework;
+
+namespace ArmoniK.Utils.DocExtractor.Tests;
+
+[TestFixture]
+public class MarkdownDocGeneratorTests
+{
+  [Test]
+  public void GenerateFromSyntaxRootShouldExtractDocsCorrectly()
+  {
+    const string code = """
+
+                        using System;
+
+                        [ExtractDocumentation("Test Description")]
+                        public class TestClass
+                        {
+                            /// <summary>This is a test property</summary>
+                            public string Name { get; set; }
+                        }
+
+                        public class ExtractDocumentationAttribute : Attribute
+                        {
+                            public ExtractDocumentationAttribute(string description) { }
+                        }
+
+                        """;
+
+    var syntaxTree      = CSharpSyntaxTree.ParseText(code);
+    var root = syntaxTree.GetRoot();
+    var markdown  = MarkdownDocGenerator.GenerateFromSyntaxRoot(root);
+
+    Assert.That(markdown, Does.Contain("## Test Description"));
+    Assert.That(markdown, Does.Contain("**TestClass__Name**"));
+    Assert.That(markdown, Does.Contain("This is a test property"));
+  }
+}


### PR DESCRIPTION
This PR introduce:

-  An `ExtractDocumentation`  attribute to be used in classes where its properties should be collected.
-  A tool to actually perform the extraction. The tool takes as input the solution file, inspects all the projects in the solution to check the classes whose properties should be collected and outputs a Markdown document with environment variable documentation. For example, if your class looks like:

```csharp

 [ExtractDocumentation("Options for Awesome Class")]
 public class AwesomeClass
{
   /// <summary> 
   /// This is a test property 
   ///</summary>
   public string Name { get; set; }

   /// <summary> 
   /// This is another test property 
   ///</summary>
   public int Age { get; set; }
}
```

Then the tool will produce the following output in the resulting markdown file:

```md

## Options for Awesome Class
- ** AwesomeClass__Name: ** string
  This is a test property 

- ** AwesomeClass__Age: ** string
  This is another test property 
```