### PR TITLE
chore: Documentation attribute should be usable in enum types

### DIFF
--- a/csharp/documentation.attribute/ExtractDocumentationAttribute.cs
+++ b/csharp/documentation.attribute/ExtractDocumentationAttribute.cs
@@ -19,9 +19,9 @@ using System;
 namespace ArmoniK.Utils.DocAttribute;
 
 /// <summary>
-///   Indicates that a class should have its property documentation collected.
+///   Indicates that a class or enum should have its property documentation collected.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class,
+[AttributeUsage(AttributeTargets.Class  | AttributeTargets.Enum,
                 Inherited = false)]
 public class ExtractDocumentationAttribute : Attribute
 {


### PR DESCRIPTION
The `ExtractDocumentation` attribute introduced in https://github.com/aneoconsulting/ArmoniK.Utils/pull/74 should also be applicable to `enum` types. 