### PR TITLE
Jf/flatten

### DIFF
--- a/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
+++ b/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
@@ -28,25 +28,26 @@ namespace ArmoniK.Utils.DocExtractor;
 /// </summary>
 public class MarkdownDocGenerator
 {
-  private readonly Dictionary<string, string?> docSections_;
-  private readonly List<SyntaxNode>            syntaxRootNodes_;
+  private readonly Dictionary<string, string?>                 docSections_;
+  private readonly Dictionary<string, MemberDeclarationSyntax> syntaxTypes_;
 
   /// <summary>
   ///   Initializes a new instance of the <see cref="MarkdownDocGenerator" /> class.
   /// </summary>
-  /// <param name="syntaxRootNodes">
-  ///   A list of syntax root nodes representing the structure of the code
-  ///   extracted from the solution's documents.
+  /// <param name="syntaxTypes">
+  ///   A dictionary of syntax root nodes representing the structure of the code
+  ///   extracted from the solution's documents. The key is the class name and
+  ///   the value is the corresponding <see cref="MemberDeclarationSyntax"/>.
   /// </param>
   /// <param name="docSections">
   ///   A dictionary mapping class names to their corresponding documentation
   ///   section identifiers, which are used for generating Markdown links.
   /// </param>
-  private MarkdownDocGenerator(List<SyntaxNode>            syntaxRootNodes,
+  private MarkdownDocGenerator(Dictionary<string, MemberDeclarationSyntax>  syntaxTypes,
                                Dictionary<string, string?> docSections)
   {
-    syntaxRootNodes_ = syntaxRootNodes;
-    docSections_     = docSections;
+    syntaxTypes_  = syntaxTypes;
+    docSections_  = docSections;
   }
 
   /// <summary>
@@ -79,8 +80,8 @@ public class MarkdownDocGenerator
     using var workspace = MSBuildWorkspace.Create();
     var       solution  = await workspace.OpenSolutionAsync(solutionPath);
 
-    var syntaxRootNodes = new List<SyntaxNode>();
-    var docSections     = new Dictionary<string, string?>();
+    var syntaxTypes = new Dictionary<string, MemberDeclarationSyntax>();
+    var docSections = new Dictionary<string, string?>();
 
     // Collect all syntax root nodes and descriptions from each decorated class
     foreach (var project in solution.Projects)
@@ -96,16 +97,26 @@ public class MarkdownDocGenerator
 
         var root = await syntaxTree.GetRootAsync()
                                    .ConfigureAwait(false);
-        syntaxRootNodes.Add(root);
 
         var types = root.DescendantNodes()
-                        .Where(n => n is ClassDeclarationSyntax || n is EnumDeclarationSyntax)
+                        .Where(n => n is ClassDeclarationSyntax or EnumDeclarationSyntax)
                         .Cast<MemberDeclarationSyntax>()
                         .Where(decl => decl.AttributeLists.SelectMany(a => a.Attributes)
-                                           .Any(attr => attr.Name.ToString() == "ExtractDocumentation"));
+                                           .Any(attr => attr.Name.ToString() == "ExtractDocumentation"))
+                        .ToDictionary(decl => decl switch
+                                              {
+                                                ClassDeclarationSyntax c => c.Identifier.Text,
+                                                EnumDeclarationSyntax e  => e.Identifier.Text,
+                                                _                        => "",
+                                              });
+
+        foreach (var type in types)
+        {
+          syntaxTypes[type.Key] = type.Value;
+        }
 
         // Collect documentation descriptions from all classes in all projects
-        foreach (var decl in types)
+        foreach (var decl in types.Values)
         {
           var description = GetAttributeDescription(decl,
                                                     "ExtractDocumentation");
@@ -123,7 +134,7 @@ public class MarkdownDocGenerator
       }
     }
 
-    return new MarkdownDocGenerator(syntaxRootNodes,
+    return new MarkdownDocGenerator(syntaxTypes,
                                     docSections);
   }
 
@@ -145,11 +156,8 @@ public class MarkdownDocGenerator
       markdownBuilder.AppendLine($"# {customTitle}");
     }
 
-    foreach (var root in syntaxRootNodes_)
-    {
-      var markdown = GenerateFromSyntaxRoot(root);
-      markdownBuilder.Append(markdown);
-    }
+    var markdown = GenerateFromSyntaxTypes();
+    markdownBuilder.Append(markdown);
 
     return markdownBuilder.ToString();
   }
@@ -199,27 +207,73 @@ public class MarkdownDocGenerator
                             ?.Content.ToFullString()
                             .Trim();
 
-    return summary?.Replace("///",
-                            "");
+    if (string.IsNullOrWhiteSpace(summary))
+    {
+      return null;
+    }
+
+    // Remove '///', trim lines, and add indentation
+    var cleanSummary = string.Join("\n",
+                              summary.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+                                     .Select(line => line.Replace("///", "").Trim()));
+    return cleanSummary;
+  }
+
+  /// <summary>
+  /// Iterates over all properties in the given class declaration and appends a flattened
+  /// representation of each one to the specified <see cref="StringBuilder"/>.
+  /// </summary>
+  /// <param name="builder">The output buffer used to collect flattened property definitions.</param>
+  /// <param name="classDecl">The class whose properties will be inspected.</param>
+  /// <param name="prefix">The name prefix used to construct the flattened property path.</param>
+  private void FlattenProperties(StringBuilder builder, ClassDeclarationSyntax? classDecl, string prefix)
+  {
+    if (classDecl == null)
+    {
+      return;
+    }
+
+    foreach (var property in classDecl.Members.OfType<PropertyDeclarationSyntax>())
+    {
+      var typeName     = property.Type.ToString();
+      var propertyName = property.Identifier.Text;
+      var summary      = GetXmlSummary(property);
+      var fullName     = $"{prefix}__{propertyName}";
+
+      // If the property is also a class, flatten its members recursively.
+      if (docSections_.TryGetValue(typeName, out var desc))
+      {
+        var nestedClass = syntaxTypes_!.GetValueOrDefault(typeName);
+        if (nestedClass != null)
+        {
+          // Build a link to the "parent" declaration
+          fullName = $"{prefix}__[{propertyName}](#{desc})";
+          FlattenProperties(builder,
+                            nestedClass as ClassDeclarationSyntax,
+                            fullName);
+          continue;
+        }
+      }
+
+      // This is a "leaf" property
+      builder.AppendLine($"- **{fullName}**: {typeName}");
+      if (!string.IsNullOrEmpty(summary))
+      {
+        builder.AppendLine($"    {summary.Trim()}\n");
+      }
+    }
   }
 
   /// <summary>
   ///   Generates Markdown documentation from a Roslyn <see cref="SyntaxNode" />.
   ///   Only classes and enums decorated with <c>[ExtractDocumentation]</c> will be processed.
   /// </summary>
-  /// <param name="root">The root syntax node of the document.</param>
   /// <returns>A Markdown string documenting the class and its public properties.</returns>
-  private string GenerateFromSyntaxRoot(SyntaxNode root)
+  private string GenerateFromSyntaxTypes()
   {
     var markdownBuilder = new StringBuilder();
 
-    var types = root.DescendantNodes()
-                    .Where(n => n is ClassDeclarationSyntax or EnumDeclarationSyntax)
-                    .Cast<MemberDeclarationSyntax>()
-                    .Where(decl => decl.AttributeLists.SelectMany(a => a.Attributes)
-                                       .Any(attr => attr.Name.ToString() == "ExtractDocumentation"));
-
-    foreach (var decl in types)
+    foreach (var decl in syntaxTypes_.Values)
     {
       var description = GetAttributeDescription(decl,
                                                 "ExtractDocumentation");
@@ -229,29 +283,7 @@ public class MarkdownDocGenerator
       {
         case ClassDeclarationSyntax classDecl:
         {
-          foreach (var property in classDecl.Members.OfType<PropertyDeclarationSyntax>())
-          {
-            var type    = property.Type.ToString();
-            var name    = property.Identifier.Text;
-            var summary = GetXmlSummary(property);
-            var envVar  = $"{classDecl.Identifier.Text}__{name}";
-
-            if (docSections_.TryGetValue(type,
-                                         out var desc))
-            {
-              markdownBuilder.AppendLine($"- **{envVar}**: [{type}](#{desc})");
-            }
-            else
-            {
-              markdownBuilder.AppendLine($"- **{envVar}**: {type}");
-            }
-
-            if (!string.IsNullOrEmpty(summary))
-            {
-              markdownBuilder.AppendLine($"\n{summary}");
-            }
-          }
-
+          FlattenProperties(markdownBuilder, classDecl, classDecl.Identifier.Text);
           break;
         }
         case EnumDeclarationSyntax enumDecl:
@@ -265,7 +297,7 @@ public class MarkdownDocGenerator
 
             if (!string.IsNullOrEmpty(summary))
             {
-              markdownBuilder.AppendLine($"\n{summary}");
+              markdownBuilder.AppendLine($"    {summary.Trim()}\n");
             }
           }
 

--- a/csharp/documentation.extraction/tests/ExtractDocumentationTest.cs
+++ b/csharp/documentation.extraction/tests/ExtractDocumentationTest.cs
@@ -138,9 +138,9 @@ public class MarkdownDocGeneratorTests
     Assert.That(markdown,
                 Does.Contain("## Options for Awesome Class"));
     Assert.That(markdown,
-                Does.Contain("**AwesomeClass__Help**: [HelperClass](#options-for-helper-class)"));
+                Does.Contain("**AwesomeClass__[Help](#options-for-helper-class)__Path**: string"));
     Assert.That(markdown,
-                Does.Contain("This is a nested property example"));
+                Does.Contain("**AwesomeClass__[Help](#options-for-helper-class)__Port**: int"));
     Assert.That(markdown,
                 Does.Contain("## Options for Helper Class"));
     Assert.That(markdown,

--- a/csharp/documentation.extraction/tests/ExtractDocumentationTest.cs
+++ b/csharp/documentation.extraction/tests/ExtractDocumentationTest.cs
@@ -64,7 +64,7 @@ public class MarkdownDocGeneratorTests
                                  /// <summary>
                                  /// This is a test property
                                  /// </summary>
-                                 public string Path { get; set; }
+                                 public string Path { get; set; } = "localhost"
 
                                  /// <summary>
                                  /// This is another test property
@@ -135,23 +135,33 @@ public class MarkdownDocGeneratorTests
     var generator = await MarkdownDocGenerator.CreateAsync(tempSolutionPath_);
     var markdown  = generator.Generate();
 
-    Assert.That(markdown,
-                Does.Contain("## Options for Awesome Class"));
-    Assert.That(markdown,
-                Does.Contain("**AwesomeClass__[Help](#options-for-helper-class)__Path**: string"));
-    Assert.That(markdown,
-                Does.Contain("**AwesomeClass__[Help](#options-for-helper-class)__Port**: int"));
-    Assert.That(markdown,
-                Does.Contain("## Options for Helper Class"));
-    Assert.That(markdown,
-                Does.Contain("This is a test property"));
-    Assert.That(markdown,
-                Does.Contain("This is another test property"));
-    Assert.That(markdown,
-                Does.Contain("Options for Enum"));
-    Assert.That(markdown,
-                Does.Contain(" This is a test member"));
-    Assert.That(markdown,
-                Does.Contain(" This is another test member"));
+    const string expected = """
+                            ## Options for Awesome Class
+                            - **AwesomeClass__[Help](#options-for-helper-class)__Path**: string (default: `"localhost"`)
+                                This is a test property
+                            - **AwesomeClass__[Help](#options-for-helper-class)__Port**: int (default: `0`)
+                                This is another test property
+
+                            ## Options for Helper Class
+                            - **HelperClass__Path**: string (default: `"localhost"`)
+                                This is a test property
+                            - **HelperClass__Port**: int (default: `0`)
+                                This is another test property
+
+                            ## Options for Enum
+                            - **Member1**
+                                This is a test member
+                            - **Member2**
+                                This is another test member
+
+                            """;
+
+    Assert.That(Normalize(markdown),
+                Is.EqualTo(Normalize(expected)));
   }
+
+  private static string Normalize(string? s)
+    => s?.Replace("\r\n",
+                  "\n")
+        .Trim() ?? "";
 }


### PR DESCRIPTION
This PR updates the extraction tool such that:
- nested classes are in-lined recursively in the generated markdown file
- default values are displayed for each class member, if no default value is found we use the default value of the  the (value) type. 

So if your class looks like:

``` csharp

[ExtractDocumentation("Options for Awesome Class")]
public class AwesomeClass
{
    public HelperClass Help { get; set; }
}

[ExtractDocumentation("Options for Helper Class")]
public class HelperClass
{
    /// <summary>
    /// This is a test property
    /// </summary>
    public string Path { get; set; }     
    
    /// <summary>
    /// This is another test property
    /// </summary>
    public int Port { get; set; }
}

[ExtractDocumentation("Options for Enum")]
public enum HelperEnum
{
    /// <summary>
    /// This is a test member
    /// </summary>
   Member1

    /// <summary>
    /// This is another test member
    /// </summary>
    Member2
}

```

The tool yields: 

``` markdown

## Options for Awesome Class
- **AwesomeClass__[Help](#options-for-helper-class)__Path**: string (default: `"localhost"`)
    This is a test property
- **AwesomeClass__[Help](#options-for-helper-class)__Port**: int (default: `0`)
    This is another 

## Options for Helper Class
- **HelperClass__Path**: string (default: `"localhost"`)
    This is a test property
- **HelperClass__Port**: int (default: `0`)
    This is another 

## Options for Enum
- **Member1**
    This is a test member
- **Member2**
    This is another test member

``` 