### PR TITLE
feat: Add support for enumerable with ObjectPool

### DIFF
--- a/csharp/src/EnumerableExt.cs
+++ b/csharp/src/EnumerableExt.cs
@@ -155,4 +155,34 @@ public static class EnumerableExt
                                maxDelay,
                                cancellationToken);
   }
+
+  /// <summary>
+  ///   Converts an <see cref="IAsyncEnumerable{T}" /> instance into an <see cref="IEnumerable{T}" /> that enumerates
+  ///   elements in a blocking manner.
+  /// </summary>
+  /// <param name="source">The source enumerable being iterated.</param>
+  /// <typeparam name="T">The type of the objects being iterated.</typeparam>
+  /// <returns>
+  ///   An <see cref="IAsyncEnumerable{T}" /> instance that enumerates the source <see cref="IAsyncEnumerable{T}" />
+  ///   in a blocking manner.
+  /// </returns>
+  [PublicAPI]
+  public static IEnumerable<T> ToBlocking<T>(this IAsyncEnumerable<T> source)
+  {
+    var enumerator = source.GetAsyncEnumerator();
+
+    try
+    {
+      while (enumerator.MoveNextAsync()
+                       .WaitSync())
+      {
+        yield return enumerator.Current;
+      }
+    }
+    finally
+    {
+      enumerator.DisposeAsync()
+                .WaitSync();
+    }
+  }
 }

--- a/csharp/tests/EnumerableExtTest.cs
+++ b/csharp/tests/EnumerableExtTest.cs
@@ -163,6 +163,13 @@ public class EnumerableExtTest
                                 orig));
   }
 
+  [Test]
+  public void ToBlockingEnumerable()
+    => Assert.That(GenerateInts(5)
+                   .ToAsyncEnumerable()
+                   .ToBlocking(),
+                   Is.EqualTo(GenerateInts(5)));
+
   private static IEnumerable<int> GenerateInts(int n)
   {
     for (var i = 0; i < n; ++i)


### PR DESCRIPTION
# Motivation

If calling an ObjectPool.WithInstance with a function returning an IEnumerable or IAsyncEnumerable, the object would be released to the pool before the enumerable being consumed.

# Description

Add overloads that take an enumerable as input and return an enumerable as output that release the object back to the pool once the enumerable has been consumed.