### PR TITLE
feat(doc extractor): support  for cref, paramref and langword xml doc elements

### DIFF
--- a/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
+++ b/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
@@ -270,7 +270,7 @@ public class MarkdownDocGenerator
               else
               {
                 var textAttr = emptyElement.Attributes.OfType<XmlTextAttributeSyntax>()
-                                            .FirstOrDefault();
+                                           .FirstOrDefault();
                 if (textAttr != null)
                 {
                   var value = string.Concat(textAttr.TextTokens.Select(t => t.Text));
@@ -285,7 +285,7 @@ public class MarkdownDocGenerator
             case "typeparamref":
             {
               var nameAttr = emptyElement.Attributes.OfType<XmlNameAttributeSyntax>()
-                                          .FirstOrDefault();
+                                         .FirstOrDefault();
               if (nameAttr != null)
               {
                 builder.Append($"`{nameAttr.Identifier.Identifier.Text}`");
@@ -337,7 +337,7 @@ public class MarkdownDocGenerator
             case "seealso":
             {
               var crefAttr = element.StartTag.Attributes.OfType<XmlCrefAttributeSyntax>()
-                                     .FirstOrDefault();
+                                    .FirstOrDefault();
               var innerText = ExtractInlineText(element.Content);
               if (!string.IsNullOrEmpty(innerText))
               {
@@ -355,7 +355,7 @@ public class MarkdownDocGenerator
             case "typeparamref":
             {
               var nameAttr = element.StartTag.Attributes.OfType<XmlNameAttributeSyntax>()
-                                     .FirstOrDefault();
+                                    .FirstOrDefault();
               if (nameAttr != null)
               {
                 builder.Append($"`{nameAttr.Identifier.Identifier.Text}`");

--- a/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
+++ b/csharp/documentation.extraction/src/MarkdownDocExtractor.cs
@@ -252,6 +252,52 @@ public class MarkdownDocGenerator
           break;
         }
 
+        case XmlEmptyElementSyntax emptyElement:
+        {
+          var name = emptyElement.Name.ToString();
+
+          switch (name)
+          {
+            case "see":
+            case "seealso":
+            {
+              var crefAttr = emptyElement.Attributes.OfType<XmlCrefAttributeSyntax>()
+                                         .FirstOrDefault();
+              if (crefAttr != null)
+              {
+                builder.Append($"`{crefAttr.Cref}`");
+              }
+              else
+              {
+                var textAttr = emptyElement.Attributes.OfType<XmlTextAttributeSyntax>()
+                                            .FirstOrDefault();
+                if (textAttr != null)
+                {
+                  var value = string.Concat(textAttr.TextTokens.Select(t => t.Text));
+                  builder.Append($"`{value}`");
+                }
+              }
+
+              break;
+            }
+
+            case "paramref":
+            case "typeparamref":
+            {
+              var nameAttr = emptyElement.Attributes.OfType<XmlNameAttributeSyntax>()
+                                          .FirstOrDefault();
+              if (nameAttr != null)
+              {
+                builder.Append($"`{nameAttr.Identifier.Identifier.Text}`");
+              }
+
+              break;
+            }
+          }
+
+          break;
+        }
+
         case XmlElementSyntax element:
         {
           var name = element.StartTag.Name.ToString();
@@ -284,6 +330,37 @@ public class MarkdownDocGenerator
             {
               var codeText = ExtractInlineText(element.Content);
               builder.Append($"`{codeText}`");
+              break;
+            }
+
+            case "see":
+            case "seealso":
+            {
+              var crefAttr = element.StartTag.Attributes.OfType<XmlCrefAttributeSyntax>()
+                                     .FirstOrDefault();
+              var innerText = ExtractInlineText(element.Content);
+              if (!string.IsNullOrEmpty(innerText))
+              {
+                builder.Append($"`{innerText}`");
+              }
+              else if (crefAttr != null)
+              {
+                builder.Append($"`{crefAttr.Cref}`");
+              }
+
+              break;
+            }
+
+            case "paramref":
+            case "typeparamref":
+            {
+              var nameAttr = element.StartTag.Attributes.OfType<XmlNameAttributeSyntax>()
+                                     .FirstOrDefault();
+              if (nameAttr != null)
+              {
+                builder.Append($"`{nameAttr.Identifier.Identifier.Text}`");
+              }
+
               break;
             }
 


### PR DESCRIPTION
  # Motivation

  C# XML documentation commonly references other types and members using <see cref="..."/>, parameters   
  using <paramref name="..."/>, and language keywords using <see langword="..."/>. These are first-class 
  constructs in the doc comment syntax, but the extractor was treating them as unknown nodes and silently
  dropping their content which might leave gaps in the generated markdown. 

# Summary
  
  This PR introduces the following changes:

  - Add handling for XmlEmptyElementSyntax nodes in RenderXmlNodes, which Roslyn produces for            
  self-closing XML doc tags — previously silently ignored                                                
  - Render <see cref="..."/> and <seealso cref="..."/> as inline code using the referenced symbol name   
  - Render <see langword="..."/> as inline code (e.g. null, true)                                        
  - Render <paramref name="..."/> and <typeparamref name="..."/> as inline code                          
  - Handle the non-self-closing form <see cref="...">display text</see>, preferring the explicit display 
  text over the cref     